### PR TITLE
Update package.json in preparation for new NPM package scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "@rwatt451/ordercloud-react",
+  "name": "@ordercloud/react-sdk",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@rwatt451/ordercloud-react",
+      "name": "@ordercloud/react-sdk",
       "version": "0.2.0",
+      "license": "MIT",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.0",
         "@react-native-async-storage/async-storage": "^2.1.0",
@@ -10247,9 +10248,10 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
-      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,35 @@
 {
-  "name": "@rwatt451/ordercloud-react",
+  "name": "@ordercloud/react-sdk",
+  "homepage": "https://ordercloud.io/",
+  "bugs": {
+    "url": "https://github.com/ordercloud-api/ordercloud-react-sdk/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ordercloud-api/ordercloud-react-sdk"
+  },
+  "license": "MIT",
   "private": false,
   "version": "0.2.0",
   "type": "module",
   "files": [
     "package.json",
     "dist"
+  ],
+  "keywords": [
+    "sitecore",
+    "ordercloud",
+    "b2b",
+    "b2c",
+    "javascript",
+    "typescript",
+    "ecommerce",
+    "api",
+    "headless",
+    "sdk",
+    "react",
+    "ui",
+    "components"
   ],
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
Added a license=MIT, relevant keywords, homepage to ordercloud.io, and repository config in package.json as well.