### PR TITLE
Make scope and customScope optional on the OrderCloud Provider

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -17,8 +17,6 @@ const INITIAL_ORDERCLOUD_CONTEXT: IOrderCloudContext = {
   },
   baseApiUrl: "https://api.ordercloud.io/v1",
   clientId: "",
-  scope: [],
-  customScope: [],
   allowAnonymous: false,
   token: undefined,
   autoApplyPromotions: false,

--- a/src/models/IOrderCloudContext.ts
+++ b/src/models/IOrderCloudContext.ts
@@ -40,8 +40,8 @@ export interface IOrderCloudContext {
 
   baseApiUrl: string;
   clientId: string;
-  scope: ApiRole[];
-  customScope: string[];
+  scope?: ApiRole[];
+  customScope?: string[];
   allowAnonymous: boolean;
   defaultErrorHandler?: (error:OrderCloudError, context:IOrderCloudErrorContext) => void;
   token?: string;

--- a/src/models/IOrderCloudProvider.ts
+++ b/src/models/IOrderCloudProvider.ts
@@ -5,8 +5,8 @@ import { OpenAPIV3 } from "openapi-types";
 export interface IOrderCloudProvider {
     baseApiUrl: string;
     clientId: string;
-    scope: ApiRole[];
-    customScope: string[];
+    scope?: ApiRole[];
+    customScope?: string[];
     allowAnonymous: boolean;
     xpSchemas?: OpenAPIV3.SchemaObject;
     autoApplyPromotions?: boolean,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,20 +2,26 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { name, version } from "./package.json";
 import path from "path";
-import dts from 'vite-plugin-dts'
+import dts from "vite-plugin-dts";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
-    lib: {      
+    lib: {
       entry: path.resolve(__dirname, "src/index.ts"),
       fileName: "index",
-      name: "ordercloud-react",
+      name: "@ordercloud/react-sdk",
     },
     rollupOptions: {
       // Externalize deps that shouldn't be bundled
-      external: ["react", "react-dom", "ordercloud-javascript-sdk", "@tanstack/react-query", "@tanstack/react-table"],
+      external: [
+        "react",
+        "react-dom",
+        "ordercloud-javascript-sdk",
+        "@tanstack/react-query",
+        "@tanstack/react-table",
+      ],
       output: {
         // Global vars to use in UMD build for externalized deps
         globals: {
@@ -23,7 +29,7 @@ export default defineConfig({
           "react-dom": "ReactDOM",
           "ordercloud-javascript-sdk": "ordercloud",
           "@tanstack/react-query": "ReactQuery",
-          "@tanstack/react-table": "ReactTable"
+          "@tanstack/react-table": "ReactTable",
         },
       },
     },
@@ -31,8 +37,11 @@ export default defineConfig({
   define: {
     pkgJson: { name, version },
   },
-  plugins: [react(), dts({ rollupTypes: true }),       nodePolyfills({
-    include: ["util", "querystring", "http", "https"],
-  }),],
-  
+  plugins: [
+    react(),
+    dts({ rollupTypes: true }),
+    nodePolyfills({
+      include: ["util", "querystring", "http", "https"],
+    }),
+  ],
 });


### PR DESCRIPTION
The OrderCloud API grants the most available scopes possible based on Security Profile assignments; therefore, we thought it made sense that these shouldn't be required by the React SDK either. See issue #6 for more details.